### PR TITLE
Imdbid from nfo and sync / sorting

### DIFF
--- a/service.subtitles.opensubtitles/resources/lib/OSUtilities.py
+++ b/service.subtitles.opensubtitles/resources/lib/OSUtilities.py
@@ -47,15 +47,31 @@ class OSDBServer:
                               'moviehash'    :hash,
                               'moviebytesize':str(size)
                             })
+          if not item['tvshow']:
+            searchlist.append({'sublanguageid' :",".join(item['3let_language']),
+          			'imdbid'	   :str(xbmc.Player().getVideoInfoTag().getIMDBNumber().replace('tt',''))
+          		       })
         except:
           pass    
 
-      searchlist.append({'sublanguageid':",".join(item['3let_language']),
-                          'query'       :OS_search_string
-                        })
-      search = self.server.SearchSubtitles( self.osdb_token, searchlist )
-      if search["data"]:
-        return search["data"] 
+      if item['mansearch']:
+      	searchlist = [{'sublanguageid':",".join(item['3let_language']),
+                       'query'        :OS_search_string
+                     }]
+      	search = self.server.SearchSubtitles( self.osdb_token, searchlist )
+      	if search["data"]:
+          return search["data"]
+      else:
+      	search = self.server.SearchSubtitles( self.osdb_token, searchlist )
+      	if search["data"]:
+          return search["data"] 
+	else: 
+	  searchlist = [{'sublanguageid':",".join(item['3let_language']),
+                	 'query'        :OS_search_string
+                       }]
+      	  search = self.server.SearchSubtitles( self.osdb_token, searchlist )
+      	  if search["data"]:
+            return search["data"]
 
 
   def download(self, ID, dest):

--- a/service.subtitles.opensubtitles/service.py
+++ b/service.subtitles.opensubtitles/service.py
@@ -40,7 +40,10 @@ def Search( item ):
     return
 
   if search_data != None:
-    search_data.sort(key=lambda x: [not x['MatchedBy'] == 'moviehash',x['LanguageName']])
+    search_data.sort(key=lambda x: [not x['MatchedBy'] == 'moviehash',
+				     not os.path.splitext(x['SubFileName'])[0] == os.path.splitext(os.path.basename(urllib.unquote(xbmc.Player().getPlayingFile().decode('utf-8'))))[0],
+				     not normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle")).lower() in x['SubFileName'].replace('.',' ').lower(),
+				     not x['LanguageName'] == PreferredSub])
     for item_data in search_data:
       listitem = xbmcgui.ListItem(label          = item_data["LanguageName"],
                                   label2         = item_data["SubFileName"],
@@ -128,6 +131,7 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
   item['title']              = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))# try to get original title
   item['file_original_path'] = urllib.unquote(xbmc.Player().getPlayingFile().decode('utf-8'))# Full path of a playing file
   item['3let_language']      = [] #['scc','eng']
+  PreferredSub		      = params.get('preferredlanguage')
 
   if 'searchstring' in params:
     item['mansearch'] = True


### PR DESCRIPTION
Added to sort the most likely wanted subtitles on top even if moviehash search fails, added another condition to mark the subtitle as in sync.

Added support for fetching IMDB id from nfo.

Changed so that if a manual string is entered, that string is the only thing being searched for. Don't append the query string to the search if searching by moviehash or IMDB id succeeded, it returns to many unwanted results. Only use the query string in the search if moviehash and IMDB id search returns empty or if manual search or if it's a TV Show.
