### PR TITLE
fixed: Don't unquote(urldecode) file_original_path as it breaks hashing

### DIFF
--- a/service.subtitles.opensubtitles/service.py
+++ b/service.subtitles.opensubtitles/service.py
@@ -132,7 +132,7 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
   item['episode']            = str(xbmc.getInfoLabel("VideoPlayer.Episode"))                 # Episode
   item['tvshow']             = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))  # Show
   item['title']              = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))# try to get original title
-  item['file_original_path'] = urllib.unquote(xbmc.Player().getPlayingFile().decode('utf-8'))# Full path of a playing file
+  item['file_original_path'] = xbmc.Player().getPlayingFile().decode('utf-8')                 # Full path of a playing file
   item['3let_language']      = [] #['scc','eng']
   PreferredSub		      = params.get('preferredlanguage')
 


### PR DESCRIPTION
I stumbled onto this while accidently checking the log while playing something from a webdav share. Unquoting/urldecoding paths will cause the filehash open function to basically open the wrong file as it's no longer url decoded causing failure. I don't know the idea behind the unquote(), it could be a remnant but it really seems wrong.
