### PR TITLE
add slash or backslash at the end of path

### DIFF
--- a/service.subtitles.opensubtitles/service.py
+++ b/service.subtitles.opensubtitles/service.py
@@ -20,7 +20,7 @@ __language__   = __addon__.getLocalizedString
 __cwd__        = xbmc.translatePath( __addon__.getAddonInfo('path') ).decode("utf-8")
 __profile__    = xbmc.translatePath( __addon__.getAddonInfo('profile') ).decode("utf-8")
 __resource__   = xbmc.translatePath( os.path.join( __cwd__, 'resources', 'lib' ) ).decode("utf-8")
-__temp__       = xbmc.translatePath( os.path.join( __profile__, 'temp') ).decode("utf-8")
+__temp__       = xbmc.translatePath( os.path.join( __profile__, 'temp', '') ).decode("utf-8")
 
 if xbmcvfs.exists(__temp__):
   shutil.rmtree(__temp__)


### PR DESCRIPTION
fix xbmcvfs.exists in Helix
http://mirrors.xbmc.org/docs/python-docs/14.x-helix/xbmcvfs.html#-exists
