### PR TITLE
Fix for Greek subtitles

### DIFF
--- a/service.subtitles.opensubtitles/service.py
+++ b/service.subtitles.opensubtitles/service.py
@@ -148,10 +148,10 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
   for lang in urllib.unquote(params['languages']).decode('utf-8').split(","):
     if lang == "Portuguese (Brazil)":
       lan = "pob"
+    if lang == "Greek":
+      lan = "ell"
     else:
       lan = xbmc.convertLanguage(lang,xbmc.ISO_639_2)
-      if lan == "gre":
-        lan = "ell"
 
     item['3let_language'].append(lan)
 


### PR DESCRIPTION
Fix for Greek subtitles broken in Kodi 15 and above.
I treated them the same way as Portuguese (Brazil) are treated.
Tested on Kodi 15.1 & 16 Alpha 2, with Greek subs only and along with other languages enabled.
